### PR TITLE
upgrading nerfplayer to work with nerfstudio 1.1.4 : nerfplayer_nerfa…

### DIFF
--- a/nerfplayer/cuda/_backend.py
+++ b/nerfplayer/cuda/_backend.py
@@ -34,8 +34,8 @@ if cuda_toolkit_available():
         _C = load(
             name=NAME,
             sources=glob.glob(os.path.join(PATH, "csrc/*.cu")),
-            extra_cflags=["-O3", "-std=c++14"],
-            extra_cuda_cflags=["-O3", "-std=c++14"],
+            extra_cflags=["-O3", "-std=c++17"],
+            extra_cuda_cflags=["-O3", "-std=c++17"],
             extra_include_paths=[],
         )
     else:
@@ -46,8 +46,8 @@ if cuda_toolkit_available():
         _C = load(
             name=NAME,
             sources=glob.glob(os.path.join(PATH, "csrc/*.cu")),
-            extra_cflags=["-O3", "-std=c++14"],
-            extra_cuda_cflags=["-O3", "-std=c++14"],
+            extra_cflags=["-O3", "-std=c++17"],
+            extra_cuda_cflags=["-O3", "-std=c++17"],
             extra_include_paths=[],
         )
         print("nerfstudio field components: Setting up CUDA finished")

--- a/nerfplayer/cuda/csrc/temporal_gridencoder.cu
+++ b/nerfplayer/cuda/csrc/temporal_gridencoder.cu
@@ -31,9 +31,9 @@
 // just for compatability of half precision in AT_DISPATCH_FLOATING_TYPES_AND_HALF...
 static inline  __device__ at::Half atomicAdd(at::Half *address, at::Half val) {
     // requires CUDA >= 10 and ARCH >= 70
-    // this is very slow compared to float or __half2, and never used.
+    // this is very slow compared to float or at::Half2, and never used.
     // The following line was commented in torch-ngp; uncomment it in case someone want to try fp16...
-    return atomicAdd(reinterpret_cast<__half*>(address), val);
+    return atomicAdd(reinterpret_cast<at::Half*>(address), val);
 }
 
 

--- a/nerfplayer/nerfplayer_nerfacto.py
+++ b/nerfplayer/nerfplayer_nerfacto.py
@@ -49,6 +49,8 @@ from nerfstudio.model_components.shaders import NormalsShader
 from nerfstudio.models.base_model import Model
 from nerfstudio.models.nerfacto import NerfactoModel, NerfactoModelConfig
 
+from nerfstudio.cameras.camera_optimizers import CameraOptimizer, CameraOptimizerConfig
+
 
 @dataclass
 class NerfplayerNerfactoModelConfig(NerfactoModelConfig):
@@ -82,6 +84,9 @@ class NerfplayerNerfactoModelConfig(NerfactoModelConfig):
     """Temporal TV balancing weight for feature channels."""
     depth_weight: float = 1e-1
     """depth loss balancing weight for feature channels."""
+
+    camera_optimizer: CameraOptimizerConfig = field(default_factory=lambda: CameraOptimizerConfig(mode="SO3xR3"))
+    """Config of the camera optimizer to use"""
 
 
 class NerfplayerNerfactoModel(NerfactoModel):
@@ -117,6 +122,10 @@ class NerfplayerNerfactoModel(NerfactoModel):
 
         self.density_fns = []
         num_prop_nets = self.config.num_proposal_iterations
+
+        self.camera_optimizer: CameraOptimizer = self.config.camera_optimizer.setup(
+            num_cameras=self.num_train_data, device="cpu"
+        )
 
         # Build the proposal network(s)
         proposal_networks: List[TemporalHashMLPDensityField] = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "nerfplayer"
-version = "0.0.1"
+version = "0.0.2"
 
 dependencies=[
-    "nerfstudio>=0.3.1"
+    "nerfstudio==1.1.4"
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
Updating the Nerf player to work with the latest nerfstudio 1.1.4, the changes done are as follows:

- /nerplayer/nerfplayer_nerfacto.py (add camera optimizers to the class parameters)

- / nerfplayer/cuda/_backend.py (upgrade the c++ compiler to c++17 which is the minimum requirement by the used pytorch version)

- /nerfplayer/cuda/csrc/temporal_gridencoder.cu (Fix type issue for c++17 compilers where __half and at::Half can not be used interchangeably)

I have tested after those changes with the nerfstudio conda environment installation and both nerfplayer-nerfacto and nerfplayer-ngp are working as expected.

Please let me know if you have any questions or comments